### PR TITLE
Modify Implementation of convert_unix_time_to_weekly() per disscussions of the group

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -44,14 +44,12 @@
 /* See time.h for details. */
 time_t convert_unix_time_to_weekly(time_t unixtime)
 {
-    uint16_t number_of_days;
     time_t seconds_since_sunday_midnght;
     struct tm ts;
 
     ts = *localtime(&unixtime);
 
-    number_of_days = ts.tm_wday ? ts.tm_wday - 1 : 6;
-    seconds_since_sunday_midnght = (number_of_days * 24 * 3600) +
+    seconds_since_sunday_midnght = (ts.tm_wday * 24 * 3600) +
             (ts.tm_hour * 3600) +
             (ts.tm_min * 60) +
             ts.tm_sec;

--- a/src/time.h
+++ b/src/time.h
@@ -22,7 +22,8 @@
  *  Does the conversion from unixtime to the weekly time, dealing with
  *  things like DST changes, etc.
  *
- *  @note The relative/weekly time is seconds since Sunday midnight.
+ *  @note The relative/weekly time is seconds since Sunday midnight, i.e. 
+ *  Saturday 23:59:59 + one second
  *
  *  @param unixtime the absolute time to convert from
  *


### PR DESCRIPTION
Modify Implementation of convert_unix_time_to_weekly() so its return value is relative to Sunday 00:00:00, i.e. midnight between Saturday and Sunday.
