### PR TITLE
Cast void on libparodus_shutdown() return, it always returns 0. 

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -246,7 +246,7 @@ static int main_loop(libpd_cfg_t *cfg, char *firewall_cmd, char *data_file, char
         }
     }
 
-    libparodus_shutdown(&hpd_instance);
+    (void ) libparodus_shutdown(&hpd_instance);
     debug_print("End of parodus_upstream\n");
     return 0;
 }


### PR DESCRIPTION
Stop coverity from flagging it by casting a (void ) to the call. 