### PR TITLE
Fix the logic for weekly schedule

### DIFF
--- a/src/schedule.c
+++ b/src/schedule.c
@@ -259,9 +259,9 @@ char* get_blocked_at_time( schedule_t *s, time_t unixtime )
         if( NULL != w_prev) {
             if( (w_prev->time < last_abs) && (last_abs <= weekly) ) {
                 rv = __convert_event_to_string( s, abs_prev );
-            } else {
-                rv = __convert_event_to_string( s, w_prev );
-            }
+            } else if (w_prev->time <= weekly) {
+                      rv = __convert_event_to_string( s, w_prev );
+                   }
         } else {
             if( last_abs <= weekly ) {
                 rv = __convert_event_to_string( s, abs_prev );

--- a/tests/test_time_changes.c
+++ b/tests/test_time_changes.c
@@ -203,8 +203,7 @@ void test_spring()
 
         next = get_blocked_at_time( s, t );
         if( t < 1520747100 ) {
-            // TODO - code is broken!
-            // CU_ASSERT( NULL == next );
+            CU_ASSERT( NULL == next );
         }
         if( (1520747100 <= t) && (t < 1520749800) ) {
             CU_ASSERT_STRING_EQUAL(next, "00:00:00:00:00:00 11:11:11:11:11:11");


### PR DESCRIPTION
Corrects the logic for the case of no absolute schedule. All tests in test_time_changes are now passing.